### PR TITLE
content type for svg/s3 uploads, fix tray click handlers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,8 @@ pipeline {
                 sh "npm i"
                 sh "SERVICE_VERSION=${PREREL_VERSION} npm run build:dev"
                 sh "echo ${GIT_SHORT_SHA} > ./build/SHA.txt"
-                sh "aws s3 cp ./build ${S3_LOC}/ --recursive"
+                sh "aws s3 cp ./build ${S3_LOC}/ --recursive --exclude '*.svg'"
+                sh "aws s3 cp ./build ${S3_LOC}/ --recursive --exclude '*' --include '*.svg' --content-type 'image/svg+xml'"
                 sh "aws s3 cp ./build/app.json ${STAGING_JSON}"
                 echo "publishing pre-release version to npm: " + PREREL_VERSION
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
@@ -52,7 +53,8 @@ pipeline {
                 sh "npm i"
                 sh "SERVICE_VERSION=${VERSION} npm run build"
                 sh "echo ${GIT_SHORT_SHA} > ./build/SHA.txt"
-                sh "aws s3 cp ./build ${S3_LOC}/ --recursive"
+                sh "aws s3 cp ./build ${S3_LOC}/ --recursive --exclude '*.svg'"
+                sh "aws s3 cp ./build ${S3_LOC}/ --recursive --exclude '*' --include '*.svg' --content-type 'image/svg+xml'"
                 sh "aws s3 cp ./build/app.json ${PROD_JSON}"
                 withCredentials([string(credentialsId: "NPM_TOKEN_WRITE", variable: 'NPM_TOKEN')]) {
                     sh "echo //registry.npmjs.org/:_authToken=$NPM_TOKEN > $WORKSPACE/.npmrc"

--- a/src/ui/css/openfin-center.css
+++ b/src/ui/css/openfin-center.css
@@ -130,7 +130,7 @@ ul {
     font-size: 12px;
     display: flex;
     position: absolute;
-    width: 166px;
+    width: 170px;
     align-items: center;
     top: 12px;
     left: 16px;

--- a/src/ui/js/TrayMenu.ts
+++ b/src/ui/js/TrayMenu.ts
@@ -63,18 +63,20 @@ export class TrayMenu {
             // left click
             if (WindowInfo.instance.getShowingStatus()) {
                 // Commented out until we resolve the runtime tray icon toast delay bug
-                // this.parent.hideWindow();
+                this.parent.hideWindow();
             } else {
                 // closes any open OpenFin notifications on window show
                 // notificationManager.closeAll();
                 this.parent.showWindow();
             }
         } else if (clickInfo.button === 2) {
-            // right click
-            this.window.moveTo(clickInfo.x, clickInfo.y - 35);
-            this.window.show();
-            this.window.setAsForeground();
-            this.window.focus();
+            // BSS - this destroys the service and is very ugly
+
+            // // right click
+            // this.window.moveTo(clickInfo.x, clickInfo.y - 35);
+            // this.window.show();
+            // this.window.setAsForeground();
+            // this.window.focus();
         }
     }
 


### PR DESCRIPTION
svg's get a content type on s3 copy
tray click toggles restored (hides center when shown - runtime bug fix resolves issue)
comment out showing the tray's window on right click, this was hideous and allowed shutting down the service