### PR TITLE
Bump to runtime v36

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/openfin/Notification-Service#readme",
   "dependencies": {
-    "openfin-layouts": "^0.9.2"
+    "openfin-layouts": "0.9.3-alpha.17"
   },
   "devDependencies": {
     "@types/cucumber": "^4.0.1",
@@ -51,7 +51,7 @@
     "fs": "0.0.1-security",
     "genversion": "^2.1.0",
     "gts": "^0.8.0",
-    "hadouken-js-adapter": "^0.35.1-alpha.2",
+    "hadouken-js-adapter": "^0.36.1-alpha.1",
     "jest": "^22.4.2",
     "mini-css-extract-plugin": "^0.4.1",
     "moment": "^2.22.1",

--- a/src/Shared/config.ts
+++ b/src/Shared/config.ts
@@ -1,0 +1,1 @@
+export const CHANNEL_NAME = 'of-notifications-service-v1';

--- a/src/app.template.json
+++ b/src/app.template.json
@@ -16,6 +16,6 @@
     },
     "runtime": {
         "arguments": "--enable-aggressive-domstorage-flushing",
-        "version": "9.61.34.25"
+        "version": "9.61.36.22"
     }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,6 +1,6 @@
 console.log('Client index.js loaded');
 
-import { CHANNEL_NAME } from '../Shared/config';
+import {CHANNEL_NAME} from '../Shared/config';
 
 import {OptionButton} from '../Shared/Models/OptionButton';
 import {Notification} from '../Shared/Models/Notification';

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,7 @@
 console.log('Client index.js loaded');
 
+import { CHANNEL_NAME } from '../Shared/config';
+
 import {OptionButton} from '../Shared/Models/OptionButton';
 import {Notification} from '../Shared/Models/Notification';
 import {ISenderInfo} from '../provider/Models/ISenderInfo';
@@ -54,8 +56,9 @@ async function createClientPromise() {
     });
 
     try {
-        const opts = {...IDENTITY, payload: {version}};
-        const clientP = fin.InterApplicationBus.Channel.connect(opts).then((client) => {
+        const opts = {payload: {version}};
+        // @ts-ignore v36 types not yet available. This is the new syntax.
+        const clientP = fin.InterApplicationBus.Channel.connect(CHANNEL_NAME, opts).then((client) => {
             // tslint:disable-next-line:no-any
             client.register('WARN', (payload: any) => console.warn(payload));
             client.register('notification-clicked', (payload: NotificationEvent&ISenderInfo, sender: ISenderInfo) => {

--- a/src/demo/app-launcher.json
+++ b/src/demo/app-launcher.json
@@ -15,7 +15,7 @@
     ],
     "runtime": {
         "arguments": "--v=1 --enable-crash-reporting",
-        "version": "9.61.34.25"
+        "version": "9.61.36.22"
     },
     "shortcut": {}
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,7 +1,6 @@
-import { CHANNEL_NAME } from '../Shared/config';
-
 import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 
+import {CHANNEL_NAME} from '../Shared/config';
 import {Notification} from '../Shared/Models/Notification';
 import {NotificationEvent} from '../Shared/Models/NotificationEvent';
 import {NotificationTypes, TypeResolver} from '../Shared/Models/NotificationTypes';

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,3 +1,5 @@
+import { CHANNEL_NAME } from '../Shared/config';
+
 import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 
 import {Notification} from '../Shared/Models/Notification';
@@ -60,7 +62,8 @@ fin.desktop.main(() => {
 async function registerService() {
     // Register the service
     const serviceId = fin.desktop.Application.getCurrent().uuid;
-    providerChannel = await fin.InterApplicationBus.Channel.create(serviceId);
+    // @ts-ignore v36 types not yet available. This is the new syntax.
+    providerChannel = await fin.InterApplicationBus.Channel.create(CHANNEL_NAME);
     centerIdentity.uuid = serviceUUID = serviceId;
 
     // handle client connections

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,8 +1,9 @@
+import {ISenderInfo} from '../provider/Models/ISenderInfo';
 import {CHANNEL_NAME} from '../Shared/config';
 
-import {ISenderInfo} from '../provider/Models/ISenderInfo';
 import {INotification} from './models/INotification';
 import {NotificationCenterAPI} from './NotificationCenterAPI';
+
 declare var window: Window&{openfin: {notifications: NotificationCenterAPI}};
 
 const IDENTITY = {

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,3 +1,5 @@
+import {CHANNEL_NAME} from '../Shared/config';
+
 import {ISenderInfo} from '../provider/Models/ISenderInfo';
 import {INotification} from './models/INotification';
 import {NotificationCenterAPI} from './NotificationCenterAPI';
@@ -11,8 +13,9 @@ const IDENTITY = {
 
 
 fin.desktop.main(async () => {
-    const opts = {...IDENTITY, payload: {version: 'center'}};
-    const pluginP = fin.InterApplicationBus.Channel.connect(opts);
+    const opts = {payload: {version: 'center'}};
+    // @ts-ignore v36 types not yet available. This is the new syntax.
+    const pluginP = fin.InterApplicationBus.Channel.connect(CHANNEL_NAME, opts);
 
     function notificationCreated(payload: INotification&ISenderInfo, sender: ISenderInfo) {
         // For testing/display purposes


### PR DESCRIPTION
Upgrade the service to use runtime version `9.61.36.22` (currently still beta),.

Also includes a layouts client upgrade to `0.9.3-alpha.17` (works with current staging service)

Required fixes for breaking changes to IAB.Channels API.