### PR TITLE
[N/A] Fix persisted data not loading into state

### DIFF
--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -92,3 +92,13 @@ fin.desktop.main(async () => {
         logit(`BUTTON CLICK on button ${buttonIndex} on notification ${notification.id}`);
     });
 });
+
+
+declare global {
+    interface Window {fire: () => void;}
+}
+
+window.fire = function fireNotifications() {
+    makeNote(`id:${Math.random() * 100}`, normalNote);
+};
+

--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -92,13 +92,3 @@ fin.desktop.main(async () => {
         logit(`BUTTON CLICK on button ${buttonIndex} on notification ${notification.id}`);
     });
 });
-
-
-declare global {
-    interface Window {fire: () => void;}
-}
-
-window.fire = function fireNotifications() {
-    makeNote(`id:${Math.random() * 100}`, normalNote);
-};
-

--- a/src/provider/controller/NotificationCenter.ts
+++ b/src/provider/controller/NotificationCenter.ts
@@ -53,9 +53,6 @@ export class NotificationCenter extends AsyncInit {
         await this.addListeners();
         renderApp(this._webWindow.document, this._store);
         await this.subscribe();
-        if (this.visible) {
-            this.toggleWindow(this.visible);
-        }
     }
 
     /**
@@ -83,7 +80,7 @@ export class NotificationCenter extends AsyncInit {
      */
     private async addListeners(): Promise<void> {
         const {window} = this._webWindow;
-        const hideOnBlur = process.env.NODE_ENV === 'production';
+        const hideOnBlur = false;
 
         if (hideOnBlur) {
             window.addListener('blurred', async () => {

--- a/src/provider/store/Store.ts
+++ b/src/provider/store/Store.ts
@@ -99,9 +99,7 @@ export class Store {
         Object.assign(initialState, {notifications});
 
         settingsStorage.iterate((value: string, key: string) => {
-            if (key === 'windowVisible') {
-                initialState[key] = JSON.parse(value);
-            }
+
         });
 
         return initialState;

--- a/src/provider/store/Store.ts
+++ b/src/provider/store/Store.ts
@@ -5,6 +5,7 @@ import {Store as ReduxStore, applyMiddleware, createStore, StoreEnhancer, Dispat
 import {Signal1} from '../common/Signal';
 import {Inject} from '../common/Injectables';
 import {notificationStorage, settingsStorage} from '../model/Storage';
+import {StoredNotification} from '../model/StoredNotification';
 
 import {ActionMap, ActionHandler, RootAction, Action, ActionOf} from './Actions';
 import {RootState, Immutable} from './State';
@@ -55,8 +56,8 @@ export class Store {
         };
     }
 
-    private reduce<T extends Action>(state: RootState|undefined, action: ActionOf<T>): RootState {
-        const handler: ActionHandler<T>|undefined = this._actionMap[action.type] as ActionHandler<T>;
+    private reduce<T extends Action>(state: RootState | undefined, action: ActionOf<T>): RootState {
+        const handler: ActionHandler<T> | undefined = this._actionMap[action.type] as ActionHandler<T>;
 
         if (handler) {
             return handler(state!, action);
@@ -91,9 +92,11 @@ export class Store {
     private getInitialState(): RootState {
         const initialState = this.cloneState(Store.INITIAL_STATE);
 
+        const notifications: StoredNotification[] = [];
         notificationStorage.iterate((value: string, key: string) => {
-            Object.assign(initialState.notifications, {[key]: JSON.parse(value)});
+            notifications.push(JSON.parse(value));
         });
+        Object.assign(initialState, {notifications});
 
         settingsStorage.iterate((value: string, key: string) => {
             if (key === 'windowVisible') {
@@ -104,7 +107,7 @@ export class Store {
         return initialState;
     }
 
-    private cloneState<T extends {}>(state: T|Immutable<T>): T {
+    private cloneState<T extends {}>(state: T | Immutable<T>): T {
         const ret: T = {} as T;
         const keys: (keyof T)[] = Object.keys(state) as (keyof T)[];
 


### PR DESCRIPTION
- Fix Notifications not being loaded into the initial state.
- Disable hideOnBlur
- Disable Notification Center window visibility matching persisted state on load. (window opening if it was open before)