### PR TITLE
[SERVICE-567] Interim application restart behaviour

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -188,7 +188,7 @@ export async function clear(id: string): Promise<boolean> {
  *  .then(console.log);
  * ```
  */
-export async function getAll(): Promise<Notification[]>{
+export async function getAll(): Promise<Notification[]> {
     // Should have some sort of input validation here...
     return tryServiceDispatch(APITopic.GET_APP_NOTIFICATIONS, undefined);
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -115,8 +115,10 @@ export function addEventListener<E extends NotificationEvent>(eventType: E['type
         throw new Error('fin is not defined. The openfin-notifications module is only intended for use in an OpenFin application.');
     }
 
-    tryServiceDispatch(APITopic.REGISTER_CLIENT, eventType);
     eventEmitter.addListener(eventType, listener);
+    if (eventEmitter.listenerCount(eventType) === 1) {
+        tryServiceDispatch(APITopic.ADD_EVENT_LISTENER, eventType);
+    }
 }
 
 export function removeEventListener(eventType: 'notification-clicked', listener: (event: NotificationClickedEvent) => void): void;
@@ -128,7 +130,9 @@ export function removeEventListener<E extends NotificationEvent>(eventType: E['t
         throw new Error('fin is not defined. The openfin-notifications module is only intended for use in an OpenFin application.');
     }
 
-    tryServiceDispatch(APITopic.UNREGISTER_CLIENT, eventType);
+    if (eventEmitter.listenerCount(eventType) === 1) {
+        tryServiceDispatch(APITopic.REMOVE_EVENT_LISTENER, eventType);
+    }
     eventEmitter.removeListener(eventType, listener);
 }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -115,6 +115,7 @@ export function addEventListener<E extends NotificationEvent>(eventType: E['type
         throw new Error('fin is not defined. The openfin-notifications module is only intended for use in an OpenFin application.');
     }
 
+    tryServiceDispatch(APITopic.REGISTER_CLIENT, eventType);
     eventEmitter.addListener(eventType, listener);
 }
 
@@ -127,6 +128,7 @@ export function removeEventListener<E extends NotificationEvent>(eventType: E['t
         throw new Error('fin is not defined. The openfin-notifications module is only intended for use in an OpenFin application.');
     }
 
+    tryServiceDispatch(APITopic.UNREGISTER_CLIENT, eventType);
     eventEmitter.removeListener(eventType, listener);
 }
 

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -29,7 +29,9 @@ export const enum APITopic {
     CLEAR_NOTIFICATION = 'clear-notification',
     GET_APP_NOTIFICATIONS = 'fetch-app-notifications',
     CLEAR_APP_NOTIFICATIONS = 'clear-app-notifications',
-    TOGGLE_NOTIFICATION_CENTER = 'toggle-notification-center'
+    TOGGLE_NOTIFICATION_CENTER = 'toggle-notification-center',
+    REGISTER_CLIENT = 'register-client',
+    UNREGISTER_CLIENT = 'unregister-client'
 }
 
 export type API = {
@@ -38,6 +40,8 @@ export type API = {
     [APITopic.CLEAR_APP_NOTIFICATIONS]: [undefined, number];
     [APITopic.GET_APP_NOTIFICATIONS]: [undefined, Notification[]];
     [APITopic.TOGGLE_NOTIFICATION_CENTER]: [undefined, void];
+    [APITopic.REGISTER_CLIENT]: [string, void];
+    [APITopic.UNREGISTER_CLIENT]: [string, void];
 };
 
 export interface CreatePayload extends NotificationOptions {

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -30,8 +30,8 @@ export const enum APITopic {
     GET_APP_NOTIFICATIONS = 'fetch-app-notifications',
     CLEAR_APP_NOTIFICATIONS = 'clear-app-notifications',
     TOGGLE_NOTIFICATION_CENTER = 'toggle-notification-center',
-    REGISTER_CLIENT = 'register-client',
-    UNREGISTER_CLIENT = 'unregister-client'
+    ADD_EVENT_LISTENER = 'register-client',
+    REMOVE_EVENT_LISTENER = 'unregister-client'
 }
 
 export type API = {
@@ -40,8 +40,8 @@ export type API = {
     [APITopic.CLEAR_APP_NOTIFICATIONS]: [undefined, number];
     [APITopic.GET_APP_NOTIFICATIONS]: [undefined, Notification[]];
     [APITopic.TOGGLE_NOTIFICATION_CENTER]: [undefined, void];
-    [APITopic.REGISTER_CLIENT]: [string, void];
-    [APITopic.UNREGISTER_CLIENT]: [string, void];
+    [APITopic.ADD_EVENT_LISTENER]: [string, void];
+    [APITopic.REMOVE_EVENT_LISTENER]: [string, void];
 };
 
 export interface CreatePayload extends NotificationOptions {

--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -51,7 +51,6 @@ function makeNoteOfType(index: number) {
 fin.desktop.main(async () => {
     const clientResponse = document.getElementById('clientResponse')!;
 
-
     function logit(msg: string) {
         const logEntry = document.createElement('div');
         logEntry.innerHTML = msg;

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -245,14 +245,18 @@ export class Main {
                 this._apiHandler.dispatchAppEvent(target.uuid, event);
             } else {
                 this._store.dispatch({type: Action.DEFER_EVENT_DISPATCH, target, event});
-                clientInfoStorage.getItem(target.uuid).then(item => {
-                    if (item) {
-                        const data = item as AppInitData;
-                        if (data.type === 'programmatic') {
-                            fin.Application.start(data.data as ApplicationOption);
-                        } else {
-                            fin.Application.startFromManifest(data.data as string);
-                        }
+                fin.Application.wrapSync(target).isRunning().then(isRunning => {
+                    if (!isRunning) {
+                        clientInfoStorage.getItem(target.uuid).then(item => {
+                            if (item) {
+                                const data = item as AppInitData;
+                                if (data.type === 'programmatic') {
+                                    fin.Application.start(data.data as ApplicationOption);
+                                } else {
+                                    fin.Application.startFromManifest(data.data as string);
+                                }
+                            }
+                        });
                     }
                 });
             }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -41,7 +41,7 @@ export class Main {
     @inject(Inject.TOAST_MANAGER)
     private _toastManager!: ToastManager;
 
-    private _interestMap: Readonly<EventInterestMap> = new EventInterestMap;
+    private readonly _interestMap: EventInterestMap = new EventInterestMap();
 
     public async register(): Promise<void> {
         Object.assign(window, {
@@ -231,13 +231,9 @@ export class Main {
     }
 
     /**
-     * Dispatches, defers or discards a notification event
-     * Each event will be dispatched directly to the client application (and each one of its registered listener for the specific event)
-     * if there is at least one online client window is listening for the specific event.
-     * Event dispatch will be deferred if there is at least one listener for the specific application is registered for the specific event
-     * but there are no connected listeners at the time the event occurs.
-     * Events will be discarded if there are no client listeners registered for the specific app or all the registered listeners for the app
-     * is unregistered.
+     * Dispatches an event if the app is actively listening for it.
+     * Defers if a currently closed app was listening for this event and didn't remove it's listeners before it exits.
+     * Ignores if the app is/was not interested in this event.
      *
      * @param target Target listener identity
      * @param event Notification event
@@ -266,7 +262,7 @@ export class Main {
     /**
      * Signal for API handler connection.
      *
-    * @param connection Identity of connected client
+     * @param connection Identity of connected client
      */
     private onApiHandlerConnection(connection: Identity): void {
         fin.Application.wrapSync(connection).getInfo().then(info => {

--- a/src/provider/model/APIHandler.ts
+++ b/src/provider/model/APIHandler.ts
@@ -91,7 +91,7 @@ export class APIHandler<T extends Enum> {
     public async registerListeners<S extends APISpecification<T>>(actionHandlerMap: APIImplementation<T, S>): Promise<void> {
         const providerChannel: ChannelProvider = this._providerChannel = await fin.InterApplicationBus.Channel.create(SERVICE_CHANNEL);
 
-        providerChannel.onConnection(this.onConnectionHandler);
+        providerChannel.onConnection(this.onConnectionHandler.bind(this));
 
         for (const action in actionHandlerMap) {
             if (actionHandlerMap.hasOwnProperty(action)) {

--- a/src/provider/model/APIHandler.ts
+++ b/src/provider/model/APIHandler.ts
@@ -2,11 +2,12 @@ import {ProviderIdentity} from 'openfin/_v2/api/interappbus/channel/channel';
 import {ChannelProvider} from 'openfin/_v2/api/interappbus/channel/provider';
 import {Identity, Application} from 'openfin/_v2/main';
 import {injectable} from 'inversify';
+import {Signal} from 'openfin-service-signal';
 
 import {SERVICE_CHANNEL} from '../../client/internal';
 import {NotificationEvent} from '../../client';
 
-import {clientInfoStorage} from './Storage';
+
 
 /**
  * Semantic type definition.
@@ -60,6 +61,7 @@ export type APIImplementation<T extends Enum, S extends APISpecification<T>> = {
 @injectable()
 export class APIHandler<T extends Enum> {
     private _providerChannel!: ChannelProvider;
+    public readonly onConnection: Signal<[Identity]> = new Signal();
 
     public get channel(): ChannelProvider {
         return this._providerChannel;
@@ -89,7 +91,7 @@ export class APIHandler<T extends Enum> {
     public async registerListeners<S extends APISpecification<T>>(actionHandlerMap: APIImplementation<T, S>): Promise<void> {
         const providerChannel: ChannelProvider = this._providerChannel = await fin.InterApplicationBus.Channel.create(SERVICE_CHANNEL);
 
-        providerChannel.onConnection(this.onConnection);
+        providerChannel.onConnection(this.onConnectionHandler);
 
         for (const action in actionHandlerMap) {
             if (actionHandlerMap.hasOwnProperty(action)) {
@@ -103,25 +105,15 @@ export class APIHandler<T extends Enum> {
     }
 
     // TODO?: Remove the need for this any by defining connection payload type?
-    private onConnection(app: Identity, payload?: any): void {
+    private onConnectionHandler(app: Identity, payload?: any): void {
         if (payload && payload.version && payload.version.length > 0) {
             console.log(`connection from client: ${app.name}, version: ${payload.version}`);
         } else {
             console.log(`connection from client: ${app.name}, unable to determine version`);
         }
 
-        fin.Application.wrap(app).then(async (application: Application) => {
-            const info = await application.getInfo();
-            clientInfoStorage.setItem(
-                app.uuid,
-                info.parentUuid ? {
-                    type: 'programmatic',
-                    data: info.initialOptions
-                } : {
-                    type: 'manifest',
-                    data: info.manifestUrl
-                }
-            );
+        setImmediate(() => {
+            this.onConnection.emit(app);
         });
     }
 }

--- a/src/provider/model/APIHandler.ts
+++ b/src/provider/model/APIHandler.ts
@@ -5,7 +5,8 @@ import {injectable} from 'inversify';
 
 import {SERVICE_CHANNEL} from '../../client/internal';
 import {NotificationEvent} from '../../client';
-import { clientInfoStorage } from './Storage';
+
+import {clientInfoStorage} from './Storage';
 
 /**
  * Semantic type definition.
@@ -71,7 +72,7 @@ export class APIHandler<T extends Enum> {
     }
 
     public async dispatchAppEvent(targetUuid: string, payload: NotificationEvent): Promise<void> {
-        let clients: Identity[] = this._providerChannel.connections.filter(c => c.uuid === targetUuid);
+        const clients: Identity[] = this._providerChannel.connections.filter(c => c.uuid === targetUuid);
         clients.forEach(client => this.dispatchClientEvent(client, payload));
     }
 
@@ -80,7 +81,7 @@ export class APIHandler<T extends Enum> {
             return identity.uuid === conn.uuid && identity.name === conn.name;
         });
     }
- 
+
     public getClientConnections(): Identity[] {
         return this._providerChannel.connections;
     }
@@ -111,14 +112,16 @@ export class APIHandler<T extends Enum> {
 
         fin.Application.wrap(app).then(async (application: Application) => {
             const info = await application.getInfo();
-            clientInfoStorage.setItem(app.uuid, 
+            clientInfoStorage.setItem(
+                app.uuid,
                 info.parentUuid ? {
                     type: 'programmatic',
                     data: info.initialOptions
                 } : {
                     type: 'manifest',
                     data: info.manifestUrl
-                });
+                }
+            );
         });
     }
 }

--- a/src/provider/model/APIHandler.ts
+++ b/src/provider/model/APIHandler.ts
@@ -7,8 +7,6 @@ import {Signal} from 'openfin-service-signal';
 import {SERVICE_CHANNEL} from '../../client/internal';
 import {NotificationEvent} from '../../client';
 
-
-
 /**
  * Semantic type definition.
  *

--- a/src/provider/model/DeferredEvent.ts
+++ b/src/provider/model/DeferredEvent.ts
@@ -1,0 +1,7 @@
+import { Identity } from "openfin/_v2/main";
+import { NotificationEvent } from "../../client";
+
+export interface DeferredEvent {
+    target: Identity;
+    event: NotificationEvent;
+}

--- a/src/provider/model/DeferredEvent.ts
+++ b/src/provider/model/DeferredEvent.ts
@@ -1,5 +1,6 @@
-import { Identity } from "openfin/_v2/main";
-import { NotificationEvent } from "../../client";
+import {Identity} from 'openfin/_v2/main';
+
+import {NotificationEvent} from '../../client';
 
 export interface DeferredEvent {
     target: Identity;

--- a/src/provider/model/EventInterestMap.ts
+++ b/src/provider/model/EventInterestMap.ts
@@ -1,4 +1,4 @@
-import { Identity } from "openfin/_v2/main";
+import {Identity} from 'openfin/_v2/main';
 
 interface AppClients {
     [uuid: string]: string[];
@@ -9,7 +9,6 @@ interface EventInterest {
 }
 
 export class EventInterestMap {
-
     private _map: EventInterest = {};
 
     public add(event: string, target: Identity): void {
@@ -17,7 +16,7 @@ export class EventInterestMap {
             return;
         }
         if (!this._map.hasOwnProperty(event)) {
-            this._map[event] = {[target.uuid] : []};
+            this._map[event] = {[target.uuid]: []};
         } else if (!this._map[event].hasOwnProperty(target.uuid)) {
             this._map[event][target.uuid] = [];
         }
@@ -34,5 +33,4 @@ export class EventInterestMap {
     public has(event: string, target: Identity): boolean {
         return this._map.hasOwnProperty(event) && this._map[event].hasOwnProperty(target.uuid) && this._map[event][target.uuid].indexOf(target.name!) !== -1;
     }
-
 }

--- a/src/provider/model/EventInterestMap.ts
+++ b/src/provider/model/EventInterestMap.ts
@@ -1,0 +1,38 @@
+import { Identity } from "openfin/_v2/main";
+
+interface AppClients {
+    [uuid: string]: string[];
+}
+
+interface EventInterest {
+    [event: string]: AppClients;
+}
+
+export class EventInterestMap {
+
+    private _map: EventInterest = {};
+
+    public add(event: string, target: Identity): void {
+        if (this.has(event, target)) {
+            return;
+        }
+        if (!this._map.hasOwnProperty(event)) {
+            this._map[event] = {[target.uuid] : []};
+        } else if (!this._map[event].hasOwnProperty(target.uuid)) {
+            this._map[event][target.uuid] = [];
+        }
+        this._map[event][target.uuid].push(target.name!);
+    }
+
+    public remove(event: string, target: Identity): void {
+        if (this.has(event, target)) {
+            const wins: string[] = this._map[event][target.uuid];
+            wins.splice(wins.indexOf(target.name!), 1);
+        }
+    }
+
+    public has(event: string, target: Identity): boolean {
+        return this._map.hasOwnProperty(event) && this._map[event].hasOwnProperty(target.uuid) && this._map[event][target.uuid].indexOf(target.name!) !== -1;
+    }
+
+}

--- a/src/provider/model/EventInterestMap.ts
+++ b/src/provider/model/EventInterestMap.ts
@@ -28,9 +28,6 @@ export class EventInterestMap {
     }
 
     public has(event: string, target: Identity): boolean {
-        return this._map.hasOwnProperty(event) &&
-               this._map[event].hasOwnProperty(target.uuid) &&
-               this._map[event][target.uuid].hasOwnProperty(target.name!) &&
-               this._map[event][target.uuid][target.name!];
+        return ((this._map[event] || {})[target.uuid] || {})[target.name!] || false;
     }
 }

--- a/src/provider/model/EventInterestMap.ts
+++ b/src/provider/model/EventInterestMap.ts
@@ -1,36 +1,36 @@
 import {Identity} from 'openfin/_v2/main';
 
-interface AppClients {
-    [uuid: string]: string[];
+interface Application {
+    [name: string]: boolean;
+}
+
+interface Event {
+    [uuid: string]: Application;
 }
 
 interface EventInterest {
-    [event: string]: AppClients;
+    [event: string]: Event;
 }
 
 export class EventInterestMap {
     private _map: EventInterest = {};
 
     public add(event: string, target: Identity): void {
-        if (this.has(event, target)) {
-            return;
-        }
-        if (!this._map.hasOwnProperty(event)) {
-            this._map[event] = {[target.uuid]: []};
-        } else if (!this._map[event].hasOwnProperty(target.uuid)) {
-            this._map[event][target.uuid] = [];
-        }
-        this._map[event][target.uuid].push(target.name!);
+        !this._map.hasOwnProperty(event) && (this._map[event] = {});
+        !this._map[event].hasOwnProperty(target.uuid) && (this._map[event][target.uuid] = {});
+        this._map[event][target.uuid][target.name!] = true;
     }
 
     public remove(event: string, target: Identity): void {
         if (this.has(event, target)) {
-            const wins: string[] = this._map[event][target.uuid];
-            wins.splice(wins.indexOf(target.name!), 1);
+            delete this._map[event][target.uuid][target.name!];
         }
     }
 
     public has(event: string, target: Identity): boolean {
-        return this._map.hasOwnProperty(event) && this._map[event].hasOwnProperty(target.uuid) && this._map[event][target.uuid].indexOf(target.name!) !== -1;
+        return this._map.hasOwnProperty(event) &&
+               this._map[event].hasOwnProperty(target.uuid) &&
+               this._map[event][target.uuid].hasOwnProperty(target.name!) &&
+               this._map[event][target.uuid][target.name!];
     }
 }

--- a/src/provider/model/Storage.ts
+++ b/src/provider/model/Storage.ts
@@ -11,3 +11,9 @@ export const notificationStorage = localforage.createInstance({
     name: 'notifications',
     storeName: 'notifications'
 });
+
+export const clientInfoStorage = localforage.createInstance({
+    driver: localforage.INDEXEDDB,
+    name: 'notifications',
+    storeName: 'clients'
+});

--- a/src/provider/model/Toast.ts
+++ b/src/provider/model/Toast.ts
@@ -55,7 +55,6 @@ export enum ToastEvent {
     CLOSED = 'closed'
 }
 
-
 export class Toast {
     public static DIRECTION: Readonly<[number, number]> = [-1, 1];
     public static eventEmitter: EventEmitter = new EventEmitter();

--- a/src/provider/store/Actions.ts
+++ b/src/provider/store/Actions.ts
@@ -1,12 +1,12 @@
 import {Action as ReduxAction} from 'redux';
+import {Identity} from 'openfin/_v2/main';
 
 import {notificationStorage, settingsStorage} from '../model/Storage';
 import {StoredNotification} from '../model/StoredNotification';
 import {DeferredEvent} from '../model/DeferredEvent';
+import {NotificationEvent} from '../../client';
 
 import {RootState, Immutable, mutable} from './State';
-import { Identity } from 'openfin/_v2/main';
-import { NotificationEvent } from '../../client';
 
 export const enum Action {
     CREATE = '@@notifications/CREATE',

--- a/src/provider/store/State.ts
+++ b/src/provider/store/State.ts
@@ -1,8 +1,10 @@
 import {StoredNotification} from '../model/StoredNotification';
+import {DeferredEvent} from '../model/DeferredEvent';
 
 export interface RootState {
     notifications: StoredNotification[];
     windowVisible: boolean;
+    deferredEvents: DeferredEvent[];
 }
 
 export type Immutable<T> = {

--- a/src/provider/store/Store.ts
+++ b/src/provider/store/Store.ts
@@ -16,7 +16,8 @@ export type StoreChangeObserver<T> = (oldValue: T, newValue: T) => void;
 export class Store {
     private static INITIAL_STATE: RootState = {
         notifications: [],
-        windowVisible: false
+        windowVisible: false,
+        deferredEvents: []
     };
 
     public readonly onAction: Signal<[RootAction]> = new Signal();

--- a/test/demo/utils/notificationsRemote.ts
+++ b/test/demo/utils/notificationsRemote.ts
@@ -11,7 +11,7 @@ export interface NotifsTestContext extends BaseWindowContext {
 const ofBrowser = new OFPuppeteerBrowser<NotifsTestContext>();
 
 export async function create(executionTarget: Identity, options: NotificationOptions) {
-    return ofBrowser.executeOnWindow(executionTarget, function(optionsRemote: NotificationOptions){
+    return ofBrowser.executeOnWindow(executionTarget, function(optionsRemote: NotificationOptions) {
         return this.notifications.create(optionsRemote);
     }, options);
 }
@@ -26,19 +26,19 @@ export async function createAndAwait(executionTarget: Identity, options: Notific
 }
 
 export async function clear(executionTarget: Identity, id: string) {
-    return ofBrowser.executeOnWindow(executionTarget, function(idRemote: string){
+    return ofBrowser.executeOnWindow(executionTarget, function(idRemote: string) {
         return this.notifications.clear(idRemote);
     }, id);
 }
 
 export async function getAll(executionTarget: Identity) {
-    return ofBrowser.executeOnWindow(executionTarget, function(){
+    return ofBrowser.executeOnWindow(executionTarget, function() {
         return this.notifications.getAll();
     });
 }
 
 export async function clearAll(executionTarget: Identity) {
-    return ofBrowser.executeOnWindow(executionTarget, function(){
+    return ofBrowser.executeOnWindow(executionTarget, function() {
         return this.notifications.clearAll();
     });
 }

--- a/test/demo/utils/ofPuppeteer.ts
+++ b/test/demo/utils/ofPuppeteer.ts
@@ -75,7 +75,7 @@ export class OFPuppeteerBrowser<WindowContext extends BaseWindowContext = BaseWi
         } else {
             const name = uuidv4();
             await page.exposeFunction(name, fn);
-            const newHandle = await page.evaluateHandle(function(this: {[k: string]: AnyFunction}, remoteName){
+            const newHandle = await page.evaluateHandle(function(this: {[k: string]: AnyFunction}, remoteName) {
                 return this[remoteName];
             }, name);
             if (!this._mountedFunctionCache.get(page)) {

--- a/test/demo/utils/spawnRemote.ts
+++ b/test/demo/utils/spawnRemote.ts
@@ -14,7 +14,7 @@ type CreateWindowType = typeof createWindowRemote;
 type CreateAppType = typeof createAppRemote;
 
 const ofBrowser = new OFPuppeteerBrowser<SpawnEnabledContext>();
-export async function createApp(executionTarget: Identity, ...spawnArgs: Parameters<CreateAppType>): Promise<Application>{
+export async function createApp(executionTarget: Identity, ...spawnArgs: Parameters<CreateAppType>): Promise<Application> {
     const identity: Identity = await ofBrowser.executeOnWindow(executionTarget, async function(...remoteArgs: Parameters<CreateAppType>) {
         const remoteApp = await this.createApp(...remoteArgs);
         return remoteApp.identity;

--- a/test/demo/utils/storageRemote.ts
+++ b/test/demo/utils/storageRemote.ts
@@ -56,8 +56,8 @@ export async function assertNotificationStored(source: Identity, note: Notificat
  *
  * Returns `undefined` if no notification is stored with given ID.
  */
-async function getStoredNotification(id: string): Promise<StoredNotification | undefined>{
-    return ofBrowser.executeOnWindow(SERVICE_IDENTITY, async function(remoteID: string): Promise<StoredNotification | undefined>{
+async function getStoredNotification(id: string): Promise<StoredNotification | undefined> {
+    return ofBrowser.executeOnWindow(SERVICE_IDENTITY, async function(remoteID: string): Promise<StoredNotification | undefined> {
         const note = await this.notificationStorage.getItem<string | null>(remoteID);
         // Localforage returns null for non-existent keys, but we will return undefined for consistency with other utils
         return note !== null ? JSON.parse(note) : undefined;


### PR DESCRIPTION
Notification Event Lifecycle

Bookkeeping/Handshake Model
- This implementation assumes the notification events are handled by the client at application level. (see limitations)
- Client applications are expected to register multiple listeners through its windows. Provider will keep track of registered application and its windows per event type basis through listener register/unregister events. (Handshake Model)

Event Dispatch/Defer/Discard:
- Each event will be dispatched directly to the client application (and each one of its registered listener for the specific event) if there is at least one online client window is listening for the specific event.
- Event dispatch will be deferred if there is at least one listener for the specific application is registered for the specific event but there are no connected listeners at the time the event occurs.
- Events will be discarded if there are no client listeners registered for the specific app or all the registered listeners for the app is unregistered.

Deferred Event Dispatch and App Relaunch behaviour
- Each event which cannot be dispatched immediately will be stored in a list to be dispatched by the provider as soon as the application (or one of its windows) performs the handshake for the specific set of events.
- Provider will store the initialisation data for each application in a database as soon as they are connected. 
- Currently the implementation assumes the existence of parentUuid property in the ApplicationInfo as a marker to decide if the application of interest was created dynamically (programmatic) or through a manifest. Programmatic applications are relaunched via its initialOptions whereas the manifest applications are relaunched through via the manifest url. (see limitations)
- Provider will try to relaunch the application as soon as an event is added to deferred events list. (see open questions)

Limitations:
- It is unrealistic to assume an application will create the same configuration of windows and listeners each time its launched and we have no feasible way to reproduce the full 3rd party application/window/listener state from the previous session (due to security reasons) which limits the notification dispatch to application level. Developer must be informed about this clearly.

Open Questions:
- Current implementation performs app relaunch regardless of event type or app configuration. Should relaunch behaviour be agreed on as a universal behaviour or be parametrised? (Through a more general app configuration, per-notification basis or per-event basis, e.g: relaunch when click event occurs but report close event only when app comes back online by user action)
- Current implementation performs no purge operation on deferred events. Will this be required? (user scenario: the application registers for an event, exits without unregistering, and never performs handshake again)
- Current implementation assumes the lifetime of events is limited to provider lifetime. Should we support storage of these events for the next provider launch?
- Off-Topic: Notification Service provider lifecycle is based on manifest-based apps. Provider exits when the last application which was launched via a manifest which uses the notification service exits. Dynamic applications which use the service loses access to the service after this point. How to handle this scenario?