### PR TITLE
[N/A] Changed "app-defined" symbols to use more dev-friendly types. 

### DIFF
--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -84,6 +84,11 @@
  */
 
 /**
+ * (Need to comment this so that above is interpreted as a file-level comment)
+ */
+import {CustomData} from '.';
+
+/**
  * Denotes a field as being an action. Defining this field (with a non-`undefined` value) will result in actions being
  * raised and sent back to the source application when the corresponding event happens.
  *
@@ -132,7 +137,7 @@ export type ActionDeclaration<T extends never, E extends never> = NotificationAc
  * });
  * ```
  */
-export type NotificationActionResult<T = {[key: string]: string}> = T;
+export type NotificationActionResult<T = CustomData> = T;
 
 /**
  * Lists the different triggers that can raise an {@link Actions|action}. Each action that is raised will result in a

--- a/src/client/actions.ts
+++ b/src/client/actions.ts
@@ -132,7 +132,7 @@ export type ActionDeclaration<T extends never, E extends never> = NotificationAc
  * });
  * ```
  */
-export type NotificationActionResult<T = {}> = T;
+export type NotificationActionResult<T = {[key: string]: string}> = T;
 
 /**
  * Lists the different triggers that can raise an {@link Actions|action}. Each action that is raised will result in a

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -138,7 +138,7 @@ export interface NotificationOptions {
 /**
  * Application-defined context data that can be attached to notifications.
  */
-export type CustomData = {};
+export type CustomData = {[key: string]: string};
 
 /**
  * A fully-hydrated form of {@link NotificationOptions}.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -138,7 +138,7 @@ export interface NotificationOptions {
 /**
  * Application-defined context data that can be attached to notifications.
  */
-export type CustomData = {[key: string]: string};
+export type CustomData = {[key: string]: any};
 
 /**
  * A fully-hydrated form of {@link NotificationOptions}.

--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -14,7 +14,7 @@ const normalNote: NotificationOptions = {
     category: 'Short',
     icon: 'favicon.ico',
     customData: {testContext: 'testContext'},
-    onSelect: 'Selected',
+    onSelect: {task: 'Selected'},
     buttons: []
 };
 
@@ -25,7 +25,7 @@ const longNote: NotificationOptions = {
     title: 'Notification Title ',
     icon: 'favicon.ico',
     customData: {testContext: 'testContext'},
-    onSelect: 'Selected',
+    onSelect: {task: 'Selected'},
     buttons: []
 };
 
@@ -35,10 +35,10 @@ const buttonNote: NotificationOptions = {
     category: 'Buttons',
     icon: 'favicon.ico',
     customData: {testContext: 'testContext'},
-    onSelect: 'Selected',
+    onSelect: {task: 'Selected'},
     buttons: [
-        {title: 'test1', iconUrl: 'favicon.ico', onClick: 'Button 1'},
-        {title: 'test2', iconUrl: 'favicon.ico', onClick: 'Button 2'}
+        {title: 'test1', iconUrl: 'favicon.ico', onClick: {btn: 'Button 1'}},
+        {title: 'test2', iconUrl: 'favicon.ico', onClick: {btn: 'Button 2'}}
     ]
 };
 


### PR DESCRIPTION
Can treat `CustomData` and `NotificationActionResult` types as a "string bucket", rather than getting 'property X not defined' errors.