### PR TITLE
[N/A] Prevent window flicker

### DIFF
--- a/src/provider/controller/NotificationCenter.ts
+++ b/src/provider/controller/NotificationCenter.ts
@@ -30,7 +30,7 @@ const windowOptions: WindowOption = {
 
 @injectable()
 export class NotificationCenter extends AsyncInit {
-    private static WIDTH: number = 388;
+    private static readonly WIDTH: number = 388;
 
     @inject(Inject.STORE)
     private _store!: Store;
@@ -135,8 +135,8 @@ export class NotificationCenter extends AsyncInit {
 
     private async hideWindowOffscreen() {
         const {window} = this._webWindow;
-        const {virtualScreen} = await fin.System.getMonitorInfo();
-        const height = virtualScreen.bottom;
+        const {virtualScreen, primaryMonitor} = await fin.System.getMonitorInfo();
+        const height = primaryMonitor.availableRect.bottom;
         await window.showAt(virtualScreen.left - NotificationCenter.WIDTH * 2, virtualScreen.top - height * 2);
         await window.hide();
     }

--- a/src/provider/model/Toast.ts
+++ b/src/provider/model/Toast.ts
@@ -114,6 +114,7 @@ export class Toast implements LayoutItem {
     */
     public async show(): Promise<void> {
         const {window: toastWindow} = await this._webWindow;
+        await this._dimensions;
         await toastWindow.show();
         this._timeout = window.setTimeout(this.timeoutHandler, this._options.timeout);
     }

--- a/src/provider/model/Toast.ts
+++ b/src/provider/model/Toast.ts
@@ -15,7 +15,7 @@ import {WebWindow, createWebWindow} from './WebWindow';
 const windowOptions: WindowOption = {
     name: 'Notification-Toast',
     url: 'ui/toast.html',
-    autoShow: true,
+    autoShow: false,
     defaultHeight: 135,
     defaultWidth: 300,
     resizable: false,
@@ -93,7 +93,11 @@ export class Toast implements LayoutItem {
         const name = `${windowOptions.name}:${this.id}`;
         this._webWindow = createWebWindow({...windowOptions, name}).then(async (webWindow) => {
             const {window, document} = webWindow;
+            const {virtualScreen} = await fin.System.getMonitorInfo();
+
             this.addListeners();
+            // Show window offscreen so it can render and then hide it
+            await window.showAt(virtualScreen.left - windowOptions.defaultWidth! * 2, virtualScreen.top - windowOptions.defaultHeight! * 2);
             await window.hide();
             renderApp(
                 notification,


### PR DESCRIPTION
Currently there is window flickering when the service starts up and each time a new toast is created.

**Changes:**
- Windows are created and the shown & moved offscreen so they can render once. This method is used in layouts aswell to hide pooled windows and preview windows.
- Notification center window doesn't flicker onto the screen on service startup.
- Toasts don't flicker on the screen when they are created.

