### PR TITLE
[N/A] Add demo uuid to the window title

### DIFF
--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -55,6 +55,8 @@ function makeNoteOfType(index: number) {
 fin.desktop.main(async () => {
     const clientResponse = document.getElementById('clientResponse')!;
 
+    document.title = fin.Window.me.uuid;
+
     function logMessage(msg: string) {
         const logEntry = document.createElement('div');
         logEntry.innerHTML = msg;


### PR DESCRIPTION
Demo apps now have their `uuid` as their title so you can tell what app you're using.