### PR TITLE
[SERVICE-580] Notification is closed when any button is clicked, or the notification is selected

### DIFF
--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -121,6 +121,7 @@ export class Main {
                     };
                     this._eventPump.push<NotificationActionEvent>(source.uuid, event);
                 }
+                this._store.dispatch(new RemoveNotifications([action.notification]));
             } else if (action instanceof ClickNotification) {
                 const {notification, source} = action.notification;
 
@@ -134,6 +135,7 @@ export class Main {
                     };
                     this._eventPump.push<NotificationActionEvent>(source.uuid, event);
                 }
+                this._store.dispatch(new RemoveNotifications([action.notification]));
             }
         });
 


### PR DESCRIPTION
This change makes sure Notification is closed when any button is clicked, or the notification is selected.

With the new service store implementation, The ordering of action dispatch is synchronised (notification-close event is dispatched after notification-action event)

