### PR TITLE
[N/A] Remove remote-redux-devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -848,15 +848,6 @@
         "redux": "^4.0.0"
       }
     },
-    "@types/remote-redux-devtools": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/remote-redux-devtools/-/remote-redux-devtools-0.5.3.tgz",
-      "integrity": "sha512-BiYLbXBzN4HA/pSgwlebtAwd35L+PD4lkUPPxzHqFQCZDP5bHTuRp8xCUQDKiU2iRWBgtI9cZRgQQR0Pv1LF3w==",
-      "dev": true,
-      "requires": {
-        "redux": "^4.0.0"
-      }
-    },
     "@types/rimraf": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
@@ -2439,12 +2430,6 @@
           }
         }
       }
-    },
-    "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
-      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -4871,12 +4856,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-params": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
-      "integrity": "sha1-uuDfq6WIoMYNeDTA2Nwv9g7u8v4=",
-      "dev": true
-    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -6996,12 +6975,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsan": {
-      "version": "3.1.13",
-      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.13.tgz",
-      "integrity": "sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g==",
-      "dev": true
-    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -7390,12 +7363,6 @@
           }
         }
       }
-    },
-    "linked-list": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
-      "integrity": "sha1-eYsP+X0bkqT9CEgPVa6k6dSdN78=",
-      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -8051,12 +8018,6 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.4.tgz",
-      "integrity": "sha512-sOJnBmY3TJQBVIBqKHoifuwygrocXg3NjS9rZSMnVl05XWSHK7Qxb177AIZQyMDjP86bz+yneozj/h9qsPLcCA==",
       "dev": true
     },
     "nanomatch": {
@@ -9750,29 +9711,6 @@
         }
       }
     },
-    "redux-devtools-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
-      "integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
-      "dev": true,
-      "requires": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.13",
-        "lodash": "^4.17.11",
-        "nanoid": "^2.0.0",
-        "remotedev-serialize": "^0.1.8"
-      }
-    },
-    "redux-devtools-instrument": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.6.tgz",
-      "integrity": "sha512-MwvY4cLEB2tIfWWBzrUR02UM9qRG2i7daNzywRvabOSVdvAY7s9BxSwMmVRH1Y/7QWjplNtOwgT0apKhHg2Qew==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.2.0",
-        "symbol-observable": "^1.0.2"
-      }
-    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -9831,29 +9769,6 @@
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
-      }
-    },
-    "remote-redux-devtools": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
-      "integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
-      "dev": true,
-      "requires": {
-        "jsan": "^3.1.13",
-        "querystring": "^0.2.0",
-        "redux-devtools-core": "^0.2.1",
-        "redux-devtools-instrument": "^1.9.4",
-        "rn-host-detect": "^1.1.5",
-        "socketcluster-client": "^14.2.1"
-      }
-    },
-    "remotedev-serialize": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz",
-      "integrity": "sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==",
-      "dev": true,
-      "requires": {
-        "jsan": "^3.1.13"
       }
     },
     "remove-trailing-separator": {
@@ -10062,12 +9977,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "rn-host-detect": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
-      "integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg==",
-      "dev": true
     },
     "rsvp": {
       "version": "4.8.5",
@@ -10961,47 +10870,6 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
           "dev": true
-        }
-      }
-    },
-    "socketcluster-client": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.0.tgz",
-      "integrity": "sha512-ppamWR5N7fa9Lb4+ffOhMA8VMJfaSBWcD3cWCwAQ0wbg5c61LsTrK2rOPEnQ/uuhQzvLkgibEFiHWsUGRWkfNg==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.2.1",
-        "clone": "2.1.1",
-        "component-emitter": "1.2.1",
-        "linked-list": "0.1.0",
-        "querystring": "0.2.0",
-        "sc-channel": "^1.2.0",
-        "sc-errors": "^1.4.1",
-        "sc-formatter": "^3.0.1",
-        "uuid": "3.2.1",
-        "ws": "7.1.0"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-          "dev": true
-        },
-        "ws": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.0.tgz",
-          "integrity": "sha512-Swie2C4fs7CkwlHu1glMePLYJJsWjzhl1vm3ZaLplD0h7OMkZyZ6kLTB/OagiU923bZrPFXuDTeEqaEN4NWG4g==",
-          "dev": true,
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/react": "^16.8.6",
     "@types/react-dom": "^16.8.2",
     "@types/react-redux": "^7.0.8",
-    "@types/remote-redux-devtools": "^0.5.3",
     "dexie": "^2.0.4",
     "express": "^4.16.2",
     "fake-indexeddb": "^2.1.1",
@@ -64,7 +63,6 @@
     "redux": "^4.0.1",
     "redux-devtools-cli": "0.0.1-1",
     "reflect-metadata": "^0.1.13",
-    "remote-redux-devtools": "^0.5.16",
     "typescript": "3.4.5"
   },
   "precommit": {


### PR DESCRIPTION
With the new store change, we aren't using the redux devtools as our implementation doesn't support it. Also the package is buggy and spams the console with errors. I'll be write a custom version of the package at a later time that works with our redux implementation and doesn't error.

Changes:
- Remove `remote-redux-devtools`