### PR TITLE
[N/A] Fix setIntervals never being cleared

### DIFF
--- a/src/demo/app.ts
+++ b/src/demo/app.ts
@@ -23,7 +23,6 @@ const normalNote: NotificationOptions = {
 };
 
 const longNote: NotificationOptions = {
-    // eslint-disable-next-line max-len
     body: `
 # H1 Title
 Some text below.

--- a/src/provider/model/FinWebWindow.ts
+++ b/src/provider/model/FinWebWindow.ts
@@ -22,7 +22,7 @@ export class FinWebWindowFactory implements WebWindowFactory {
         const document = nativeWindow.document;
         const windowV2 = fin.Window.wrapSync({name: windowV1.name, uuid: windowV1.uuid});
 
-        const webWindow = new FinWebWindow(windowV2, document);
+        const webWindow = new FinWebWindow(windowV2, document, nativeWindow);
 
         document.addEventListener('mouseenter', () => webWindow.onMouseEnter.emit());
         document.addEventListener('mouseleave', () => webWindow.onMouseLeave.emit());
@@ -39,13 +39,15 @@ export class FinWebWindow implements WebWindow {
 
     private readonly _document: Document;
     private readonly _window: _Window;
+    private readonly _navtiveWindow: Window;
 
     private _isActive: boolean;
     private _closePromise!: Promise<void>;
 
-    constructor(window: _Window, document: Document) {
+    constructor(window: _Window, document: Document, nativeWindow: Window) {
         this._window = window;
         this._document = document;
+        this._navtiveWindow = nativeWindow;
 
         this._isActive = true;
         this._window.addListener('closing', () => {
@@ -55,6 +57,10 @@ export class FinWebWindow implements WebWindow {
 
     public get document(): Document {
         return this._document;
+    }
+
+    public get nativeWindow(): Window {
+        return this._navtiveWindow;
     }
 
     public async show(): Promise<void> {

--- a/src/provider/model/FinWebWindow.ts
+++ b/src/provider/model/FinWebWindow.ts
@@ -21,8 +21,7 @@ export class FinWebWindowFactory implements WebWindowFactory {
         const nativeWindow = windowV1.getNativeWindow();
         const document = nativeWindow.document;
         const windowV2 = fin.Window.wrapSync({name: windowV1.name, uuid: windowV1.uuid});
-
-        const webWindow = new FinWebWindow(windowV2, document, nativeWindow);
+        const webWindow = new FinWebWindow(windowV2, nativeWindow);
 
         document.addEventListener('mouseenter', () => webWindow.onMouseEnter.emit());
         document.addEventListener('mouseleave', () => webWindow.onMouseLeave.emit());
@@ -44,9 +43,9 @@ export class FinWebWindow implements WebWindow {
     private _isActive: boolean;
     private _closePromise!: Promise<void>;
 
-    constructor(window: _Window, document: Document, nativeWindow: Window) {
+    constructor(window: _Window, nativeWindow: Window) {
         this._window = window;
-        this._document = document;
+        this._document = nativeWindow.document;
         this._navtiveWindow = nativeWindow;
 
         this._isActive = true;

--- a/src/provider/model/WebWindow.ts
+++ b/src/provider/model/WebWindow.ts
@@ -12,6 +12,7 @@ export interface WebWindow {
     onBlurred: Signal<[]>;
 
     document: Document;
+    nativeWindow: Window;
 
     show(): Promise<void>;
     showAt(left: number, top: number): Promise<void>;

--- a/src/provider/view/components/NotificationTime/NotificationTime.tsx
+++ b/src/provider/view/components/NotificationTime/NotificationTime.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import {getDate} from '../../utils/Time';
+import {WindowContext} from '../Wrappers/WindowContext';
 
 interface Props {
     date: number;
@@ -8,19 +9,18 @@ interface Props {
 
 export function NotificationTime(props: Props) {
     const {date} = props;
-
+    const window = React.useContext(WindowContext);
     const [formattedDate, setFormattedDate] = React.useState<string>(getDate(date));
 
-    // Update timestamp
     React.useEffect(() => {
-        const timer = setInterval(() => {
+        const timer = window.setInterval(() => {
             setFormattedDate(getDate(date));
-        }, 1000 * 60);
+        }, 60 * 1000);
 
         return () => {
-            clearTimeout(timer);
+            window.clearInterval(timer);
         };
-    });
+    }, []);
 
     return (
         <div className="time single-line">

--- a/src/provider/view/components/Wrappers/WindowContext.tsx
+++ b/src/provider/view/components/Wrappers/WindowContext.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export const WindowContext = React.createContext<Window>(window);
+export const WindowProvider = WindowContext.Provider;
+export const WindowConsumer = WindowContext.Consumer;

--- a/src/provider/view/containers/NotificationCenterApp/NotificationCenterApp.tsx
+++ b/src/provider/view/containers/NotificationCenterApp/NotificationCenterApp.tsx
@@ -11,6 +11,7 @@ import {RemoveNotifications} from '../../../store/Actions';
 import {GroupingType} from '../../utils/Grouping';
 import {WebWindow} from '../../../model/WebWindow';
 import {Actionable} from '../../types';
+import {WindowProvider, WindowContext} from '../../components/Wrappers/WindowContext';
 
 import '../../styles/_main.scss';
 import './NotificationCenterApp.scss';
@@ -20,10 +21,14 @@ type Props = ReturnType<typeof mapStateToProps> & Actionable;
 export function NotificationCenterApp(props: Props) {
     const [groupBy, setGroupBy] = React.useState(GroupingType.DATE);
     const {notifications, applications, visible, storeApi, centerLocked} = props;
-
+    const window = React.useContext(WindowContext);
     const handleClearAll = () => {
         new RemoveNotifications(notifications).dispatch(storeApi);
     };
+
+    React.useEffect(() => {
+        window.document.title = 'Center';
+    });
 
     return (
         <div className='notification-center'>
@@ -64,9 +69,11 @@ export function renderApp(webWindow: WebWindow, store: ServiceStore): void {
     ReactDOM.render(
         // Replace redux store with service store implementation.
         // This will resolve the interface incompatibility issues.
-        <Provider store={store as unknown as Store<RootState>}>
-            <Container storeApi={store} />
-        </Provider>,
+        <WindowProvider value={webWindow.nativeWindow}>
+            <Provider store={store as unknown as Store<RootState>}>
+                <Container storeApi={store} />
+            </Provider>
+        </WindowProvider>,
         webWindow.document.getElementById('react-app')
     );
 }

--- a/src/provider/view/containers/NotificationCenterApp/NotificationCenterApp.tsx
+++ b/src/provider/view/containers/NotificationCenterApp/NotificationCenterApp.tsx
@@ -69,11 +69,11 @@ export function renderApp(webWindow: WebWindow, store: ServiceStore): void {
     ReactDOM.render(
         // Replace redux store with service store implementation.
         // This will resolve the interface incompatibility issues.
-        <WindowProvider value={webWindow.nativeWindow}>
-            <Provider store={store as unknown as Store<RootState>}>
+        <Provider store={store as unknown as Store<RootState>}>
+            <WindowProvider value={webWindow.nativeWindow}>
                 <Container storeApi={store} />
-            </Provider>
-        </WindowProvider>,
+            </WindowProvider>
+        </Provider>,
         webWindow.document.getElementById('react-app')
     );
 }

--- a/src/provider/view/containers/ToastApp/ToastApp.tsx
+++ b/src/provider/view/containers/ToastApp/ToastApp.tsx
@@ -11,6 +11,7 @@ import {Point} from '../../../model/Toast';
 import {WebWindow} from '../../../model/WebWindow';
 import {ServiceStore} from '../../../store/ServiceStore';
 import {TitledNotification, Actionable} from '../../types';
+import {WindowProvider, WindowContext} from '../../components/Wrappers/WindowContext';
 
 import '../../styles/base.scss';
 import './ToastApp.scss';
@@ -24,6 +25,11 @@ type Props = ToastAppProps & ReturnType<typeof mapStateToProps>;
 
 export function ToastApp(props: Props) {
     const {notification, setWindowSize, storeApi} = props;
+    const window = React.useContext(WindowContext);
+
+    React.useEffect(() => {
+        window.document.title = notification.id;
+    });
 
     return (
         <ResizeWrapper onSize={setWindowSize}>
@@ -49,11 +55,11 @@ export function renderApp(
         title: (store.state.applications.get(notification.source.uuid) || {title: notification.source.name || ''}).title
     };
     ReactDOM.render(
-        // Replace redux store with service store implementation.
-        // This will resolve the interface incompatibility issues.
-        <Provider store={store as unknown as Store<RootState>}>
-            <Container storeApi={store} notification={titledNotification} setWindowSize={setWindowSize} />
-        </Provider>,
+        <WindowProvider value={webWindow.nativeWindow}>
+            <Provider store={store as unknown as Store<RootState>}>
+                <Container storeApi={store} notification={titledNotification} setWindowSize={setWindowSize} />
+            </Provider>
+        </WindowProvider>,
         webWindow.document.getElementById('react-app')
     );
 }

--- a/src/provider/view/containers/ToastApp/ToastApp.tsx
+++ b/src/provider/view/containers/ToastApp/ToastApp.tsx
@@ -55,11 +55,13 @@ export function renderApp(
         title: (store.state.applications.get(notification.source.uuid) || {title: notification.source.name || ''}).title
     };
     ReactDOM.render(
-        <WindowProvider value={webWindow.nativeWindow}>
-            <Provider store={store as unknown as Store<RootState>}>
+        // Replace redux store with service store implementation.
+        // This will resolve the interface incompatibility issues.
+        <Provider store={store as unknown as Store<RootState>}>
+            <WindowProvider value={webWindow.nativeWindow}>
                 <Container storeApi={store} notification={titledNotification} setWindowSize={setWindowSize} />
-            </Provider>
-        </WindowProvider>,
+            </WindowProvider>
+        </Provider>,
         webWindow.document.getElementById('react-app')
     );
 }


### PR DESCRIPTION
Add `WindowContext` so the correct document/window can be used by components. Previously the provider `window` was the scope of all `window` or `document` calls. This caused all `setInterval` & `setTimeout` calls invoked in React components to not be cleared when the component unmounted or a toast closed as they were using the provider window.