### PR TITLE
[N/A] Fix toast time/action alignment

### DIFF
--- a/src/provider/view/components/NotificationCard/NotificationCard.scss
+++ b/src/provider/view/components/NotificationCard/NotificationCard.scss
@@ -22,6 +22,14 @@
         .text {
             max-height: $toast-max-height !important;
         }
+
+        .header {
+            padding-bottom: 9px !important;
+
+            .time {
+                top: 1px !important;
+            }
+        }
     }
 
     &.uninteractable {


### PR DESCRIPTION
Fixes the alignment of toast's time & close/minimize buttons being a few pixels too low.