### PR TITLE
[N/A] Fix for applications occasionally not restarting

### DIFF
--- a/src/provider/model/ClientRegistry.ts
+++ b/src/provider/model/ClientRegistry.ts
@@ -36,6 +36,7 @@ export class ClientRegistry {
 
         this._store = store;
         this._environment = environment;
+        this._environment.onWindowClosed.add(this.removeActiveClient, this);
     }
 
     /**

--- a/src/provider/model/Environment.ts
+++ b/src/provider/model/Environment.ts
@@ -1,4 +1,6 @@
 import {ApplicationOption} from 'openfin/_v2/api/application/applicationOption';
+import {Signal} from 'openfin-service-signal';
+import {Identity} from 'openfin/_v2/main';
 
 import {Immutable} from '../store/State';
 
@@ -20,6 +22,8 @@ type ManifestApplication = {
 }
 
 export interface Environment {
+    onWindowClosed: Signal<[Identity]>;
+
     isApplicationRunning(uuid: string): Promise<boolean>;
     getApplication(uuid: string): Promise<StoredApplication>;
     startApplication(application: StoredApplication): Promise<void>;

--- a/src/provider/model/FinEnvironment.ts
+++ b/src/provider/model/FinEnvironment.ts
@@ -1,5 +1,8 @@
 import {ApplicationOption} from 'openfin/_v2/api/application/applicationOption';
 import {injectable} from 'inversify';
+import {Identity} from 'openfin/_v2/main';
+import {Signal} from 'openfin-service-signal';
+import {WindowEvent} from 'openfin/_v2/api/events/base';
 
 import {mutable} from '../store/State';
 
@@ -7,7 +10,16 @@ import {Environment, StoredApplication} from './Environment';
 
 @injectable()
 export class FinEnvironment implements Environment {
+    public readonly onWindowClosed: Signal<[Identity]> = new Signal();
+
     private _startingUpAppUuids: string[] = [];
+
+    constructor() {
+        fin.System.addListener('window-closed', (event: WindowEvent<'system', 'window-closed'>) => {
+            const identity: Identity = {uuid: event.uuid, name: event.name};
+            this.onWindowClosed.emit(identity);
+        });
+    }
 
     public async isApplicationRunning(uuid: string): Promise<boolean> {
         if (this._startingUpAppUuids.some(startingUuid => startingUuid === uuid)) {

--- a/test/provider/model/ClientRegistry.unittest.ts
+++ b/test/provider/model/ClientRegistry.unittest.ts
@@ -19,6 +19,7 @@ beforeEach(async () => {
 
     getterMock(mockApiHandler, 'onConnection').mockReturnValue(new Signal<[Identity]>());
     getterMock(mockApiHandler, 'onDisconnection').mockReturnValue(new Signal<[Identity]>());
+    getterMock(mockEnvironment, 'onWindowClosed').mockReturnValue(new Signal<[Identity]>());
 });
 
 describe('When attempting to launch an app through the client registry', () => {

--- a/test/utils/unit/mocks.ts
+++ b/test/utils/unit/mocks.ts
@@ -1,8 +1,9 @@
-import {Identity} from 'openfin/_v2/main';
+import {Identity, System} from 'openfin/_v2/main';
 import {TrayInfo, Application} from 'openfin/_v2/api/application/application';
 import {WindowOption} from 'openfin/_v2/api/window/windowOption';
 import {ApplicationOption} from 'openfin/_v2/api/application/applicationOption';
 import {SubOptions} from 'openfin/_v2/api/base';
+import {SystemEvents} from 'openfin/_v2/api/events/system';
 
 import {Environment, StoredApplication} from '../../../src/provider/model/Environment';
 import {APIHandler} from '../../../src/provider/model/APIHandler';
@@ -59,6 +60,8 @@ const toastManagerPath = '../../../src/provider/controller/ToastManager';
 const collectionPath = '../../../src/provider/model/database/Collection';
 const actionPath = '../../../src/provider/store/Store';
 
+type AddListenerParams = [string, (...args: any[]) => void, SubOptions];
+
 export function createMockApiHandler(): jest.Mocked<APIHandler<APITopic, Events>> {
     const {APIHandler} = jest.requireMock(apiHandlerPath);
 
@@ -96,11 +99,16 @@ export function createMockDatabase(): jest.Mocked<Database> {
 }
 
 export function createMockEnvironment(): jest.Mocked<Environment> {
-    return {
+    const env: jest.Mocked<Environment> = {
+        onWindowClosed: null!,
         isApplicationRunning: jest.fn<Promise<boolean>, [string]>(),
         getApplication: jest.fn<Promise<StoredApplication>, [string]>(),
         startApplication: jest.fn<Promise<void>, [StoredApplication]>()
     };
+
+    assignMockGetter(env, 'onWindowClosed');
+
+    return env;
 }
 
 export function createMockEventPump(): jest.Mocked<EventPump> {
@@ -214,6 +222,9 @@ export function createMockFin(): MockFin {
             wrapSync: jest.fn<Promise<Application>, [Identity]>(),
             createFromManifest: jest.fn<Promise<Application>, [string]>(),
             create: jest.fn<Promise<Application>, [ApplicationOption]>()
+        },
+        System: {
+            addListener: jest.fn<Promise<System>, AddListenerParams>()
         }
     };
 
@@ -223,8 +234,6 @@ export function createMockFin(): MockFin {
 }
 
 export function createMockApplication(): jest.Mocked<Application> {
-    type AddListenerParams = [string, (...args: any[]) => void, SubOptions];
-
     return {
         addListener: jest.fn<Promise<Application>, AddListenerParams>(),
         run: jest.fn<Promise<void>, []>()


### PR DESCRIPTION
`ClientRegistry` now also listens to window-closed events, and treats them in the same way as disconnection events. This is a work-around for the IAB channel disconnection events sometimes not firing.