### PR TITLE
[N/A] Use correct WebWindowContext

### DIFF
--- a/src/provider/view/components/NotificationTime/NotificationTime.tsx
+++ b/src/provider/view/components/NotificationTime/NotificationTime.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {getDate} from '../../utils/Time';
-import {WindowContext} from '../Wrappers/WindowContext';
+import {WebWindowContext} from '../../contexts/WebWindowContext';
 
 interface Props {
     date: number;
@@ -9,7 +9,7 @@ interface Props {
 
 export function NotificationTime(props: Props) {
     const {date} = props;
-    const window = React.useContext(WindowContext);
+    const window = React.useContext(WebWindowContext).nativeWindow;
     const [formattedDate, setFormattedDate] = React.useState<string>(getDate(date));
 
     React.useEffect(() => {

--- a/src/provider/view/components/Wrappers/WindowContext.tsx
+++ b/src/provider/view/components/Wrappers/WindowContext.tsx
@@ -1,5 +1,0 @@
-import * as React from 'react';
-
-export const WindowContext = React.createContext<Window>(window);
-export const WindowProvider = WindowContext.Provider;
-export const WindowConsumer = WindowContext.Consumer;

--- a/src/provider/view/containers/NotificationCenterApp/NotificationsPanel/NotificationsPanel.tsx
+++ b/src/provider/view/containers/NotificationCenterApp/NotificationsPanel/NotificationsPanel.tsx
@@ -6,7 +6,6 @@ import {Header} from '../../../components/Header/Header';
 import {NotificationView} from '../../../components/NotificationView/NotificationView';
 import {RootState} from '../../../../store/State';
 import {usePreduxStore} from '../../../utils/usePreduxStore';
-import {WindowContext} from '../../../components/Wrappers/WindowContext';
 import {GroupingType} from '../../../utils/Grouping';
 import {ClassNameBuilder} from '../../../utils/ClassNameBuilder';
 import {ROUTES} from '../../../routes';
@@ -14,6 +13,7 @@ import {Icon} from '../../../components/Icon/Icon';
 import SettingsIcon from '../../../../../../res/provider/ui/image/shapes/Settings.svg';
 import {StoredNotification} from '../../../../model/StoredNotification';
 import {StoredApplication} from '../../../../model/Environment';
+import {WebWindowContext} from '../../../contexts/WebWindowContext';
 
 import * as Styles from './NotificationsPanel.module.scss';
 
@@ -28,7 +28,7 @@ const NotificationsPanelComponent: React.FC<Props> = (props) => {
     const {notifications, applications, history} = props;
     const storeApi = usePreduxStore();
     const [groupBy, setGroupBy] = React.useState(GroupingType.DATE);
-    const window = React.useContext(WindowContext);
+    const window = React.useContext(WebWindowContext);
 
     React.useEffect(() => {
         window.document.title = 'Center';

--- a/src/provider/view/containers/ToastApp/ToastApp.tsx
+++ b/src/provider/view/containers/ToastApp/ToastApp.tsx
@@ -6,10 +6,10 @@ import {ResizeWrapper} from '../../components/Wrappers/ResizeWrapper';
 import {RootState} from '../../../store/State';
 import {Point} from '../../../model/Toast';
 import {TitledNotification, Actionable} from '../../types';
-import {WindowContext} from '../../components/Wrappers/WindowContext';
 import '../../styles/main.scss';
 import './ToastApp.scss';
 import {StoredNotification} from '../../../model/StoredNotification';
+import {WebWindowContext} from '../../contexts/WebWindowContext';
 
 interface ToastAppProps extends Actionable {
     notification: StoredNotification;
@@ -18,7 +18,7 @@ interface ToastAppProps extends Actionable {
 
 const ToastAppComponent: React.FC<ToastAppProps> = (props) => {
     const {notification, setWindowSize, storeApi} = props;
-    const window = React.useContext(WindowContext);
+    const window = React.useContext(WebWindowContext);
     const titledNotification: TitledNotification = {
         ...notification,
         title: (storeApi.state.applications.get(notification.source.uuid) || {title: notification.source.name || ''}).title


### PR DESCRIPTION
The new render route functions use a different window context. This PR removes the old one and uses the new one.