### PR TITLE
[N/A] Use built in `Omit`

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,7 +11,7 @@
 import {ActionDeclaration, NotificationActionResult, ActionTrigger} from './actions';
 import {tryServiceDispatch, eventEmitter, getEventRouter} from './connection';
 import {ButtonOptions, ControlOptions} from './controls';
-import {APITopic, Events, NotificationInternal, Omit} from './internal';
+import {APITopic, Events, NotificationInternal} from './internal';
 import {EventRouter, Transport} from './EventRouter';
 import * as provider from './provider';
 import {validateEnvironment, sanitizeEventType, sanitizeFunction} from './validation';

--- a/src/client/internal.ts
+++ b/src/client/internal.ts
@@ -14,8 +14,6 @@ import {ProviderStatus} from './provider';
 
 import {NotificationOptions, Notification, NotificationActionEvent, NotificationClosedEvent, NotificationCreatedEvent} from './index';
 
-export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
-
 /**
  * The identity of the main application window of the service provider
  */


### PR DESCRIPTION
I bumped the TS version to use Omit (not realizing we already had our own Omit), and now we can get rid of our own Omit